### PR TITLE
feat: atualiza projeto para Java 21 e Spring Boot 3.2.3

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,25 @@
+# RabbitMQ Configuration
+spring.rabbitmq.host=localhost
+spring.rabbitmq.port=5672
+spring.rabbitmq.username=guest
+spring.rabbitmq.password=guest
+
+# RabbitMQ Exchange and Queue Configuration
+rabbitmq.exchange.name=demo.exchange
+rabbitmq.queue.name=demo.queue
+rabbitmq.routing.key=demo.routingkey
+rabbitmq.dead-letter.exchange=demo.dlx
+rabbitmq.dead-letter.queue=demo.dlq
+rabbitmq.dead-letter.routing-key=demo.dlq.routingkey
+
+# Server Configuration
+server.port=8080
+
+# Logging Configuration
+logging.level.org.springframework.amqp=INFO
+logging.level.br.com.springbootrmq=DEBUG
+
+# Zipkin Configuration
+spring.zipkin.base-url=http://localhost:9411/
+spring.zipkin.enabled=true
+spring.sleuth.sampler.probability=1.0

--- a/src/main/resources/docker-compose.yaml
+++ b/src/main/resources/docker-compose.yaml
@@ -1,31 +1,46 @@
-version: '3'
+version: '3.8'
+
 services:
-  oracle:
-    image: sath89/oracle-12c
-    ports:
-        - 1525:1525
-    environment:
-        - ORACLE_ALLOW_REMOTE=true
-        - WEB_CONSOLE=false
-        - ORACLE_SID=xe  
   rabbitmq:
-    image: rabbitmq:management
-    expose:
-     - "5672"
+    image: rabbitmq:3.12-management
+    container_name: rabbitmq
     ports:
-     - "15672:15672"
-     - "5672:5672"
-    networks:
-      - default
-  zipkin:
-    image: "openzipkin/zipkin"
-    depends_on:
-     - rabbitmq
-    links:
-     - rabbitmq
+      - "5672:5672"  # AMQP protocol port
+      - "15672:15672"  # Management UI port
     environment:
-     - RABBIT_URI=amqp://rabbitmq
+      - RABBITMQ_DEFAULT_USER=guest
+      - RABBITMQ_DEFAULT_PASS=guest
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+    networks:
+      - app-network
+
+  zipkin:
+    image: openzipkin/zipkin
+    container_name: zipkin
     ports:
       - "9411:9411"
     networks:
-      - default
+      - app-network
+
+  oracle:
+    image: container-registry.oracle.com/database/express:21.3.0-xe
+    container_name: oracle
+    ports:
+      - "1521:1521"
+      - "5500:5500"
+    environment:
+      - ORACLE_PWD=oracle
+      - ORACLE_CHARACTERSET=AL32UTF8
+    volumes:
+      - oracle_data:/opt/oracle/oradata
+    networks:
+      - app-network
+
+volumes:
+  rabbitmq_data:
+  oracle_data:
+
+networks:
+  app-network:
+    driver: bridge


### PR DESCRIPTION
## Descrição
Este PR atualiza o projeto para usar Java 21 e Spring Boot 3.2.3, além de adicionar várias melhorias na estrutura e documentação do projeto.

### Principais Alterações

#### Atualizações de Tecnologia
- ⬆️ Java 21
- ⬆️ Spring Boot 3.2.3
- ⬆️ RabbitMQ 3.12
- ⬆️ Oracle Database 21c

#### Novas Funcionalidades
- ✨ Configuração de Dead Letter Queue (DLQ)
- ✨ Suporte a mensagens JSON com Jackson2
- ✨ Rastreamento distribuído com Zipkin
- ✨ Logs aprimorados

#### Melhorias na Estrutura
- 🏗️ Reorganização do código em pacotes
- 🏗️ Uso de Records do Java 21
- 🏗️ Injeção de dependências via construtor
- 🏗️ Configuração externalizada

#### Documentação
- 📝 README.md completamente reescrito
- 📝 Adição de badges
- 📝 Instruções detalhadas de instalação
- 📝 Documentação da estrutura do projeto

### Como Testar
1. Clone o projeto
2. Execute `docker-compose up -d`
3. Execute `mvn clean install`
4. Inicie a aplicação
5. Teste o endpoint POST `/api/messages`

### Checklist
- [x] Código atualizado para Java 21
- [x] Dependências atualizadas
- [x] Testes passando
- [x] Documentação atualizada
- [x] Docker Compose atualizado